### PR TITLE
removing dup define

### DIFF
--- a/include/oni/utils/kdlsym/orbis501.h
+++ b/include/oni/utils/kdlsym/orbis501.h
@@ -22,7 +22,6 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_kmem_free						 		 0x000FCD40
 #define kdlsym_addr_kproc_create							 0x00137CE0
 
-#define kdlsym_addr_kproc_create							 0x00137CE0
 #define kdlsym_addr_sys_mlockall							 0x0013E1F0
 #define kdlsym_addr_sys_mlock								 0x0013E140
 


### PR DESCRIPTION
kproc_create was defined twice. removing dup