### PR TITLE
Fixed 5.05 support

### DIFF
--- a/include/oni/utils/kdlsym/orbis505.h
+++ b/include/oni/utils/kdlsym/orbis505.h
@@ -89,6 +89,7 @@ for the platforms that do enable kernel ASLR (Address Space Layout Randomization
 #define kdlsym_addr_eventhandler_register	0x001EC400
 #define kdlsym_addr_prison0					0x10986A0
 #define kdlsym_addr_rootvnode				0x22C1A70
+#define	kdlsym_addr_copyin									 0x001EA710
 #define kdlsym_addr_self_orbis_sysvec		0x019bbcd0
 #define kdlsym_addr_trap_fatal				0x00171580
 #define	kdlsym_addr_memcmp                  0x50ac0

--- a/src/oni/boot/patches/patches505.c
+++ b/src/oni/boot/patches/patches505.c
@@ -1,4 +1,4 @@
-#include <mira/boot/patches.h>
+#include <oni/boot/patches.h>
 #include <oni/utils/kdlsym.h>
 #include <oni/utils/cpu.h>
 

--- a/src/oni/boot/patches/patches505.c
+++ b/src/oni/boot/patches/patches505.c
@@ -1,49 +1,52 @@
-#include <oni/boot/patches.h>
+#include <mira/boot/patches.h>
 #include <oni/utils/kdlsym.h>
 #include <oni/utils/cpu.h>
 
-void install_prerunPatches_501()
+void install_prerunPatches_505()
 {
 	// You must assign the kernel base pointer before anything is done
 	if (!gKernelBase)
 		return;
 
 	void(*critical_enter)(void) = kdlsym(critical_enter);
-	void(*crtical_exit)(void) = kdlsym(critical_exit);
+	void(*critical_exit)(void) = kdlsym(critical_exit);
 
 	// Apply patches
 	critical_enter();
 	cpu_disable_wp();
-
+	
 	// enable UART
-	gKernelBase[0x09ECAE0] = 0;
+  	gKernelBase[0x19ECEB0] = 0;
 
 	// Verbose Panics
-	uint8_t *kmem = (uint8_t *)&gKernelBase[0x171517];
+	uint8_t *kmem = (uint8_t *)&gKernelBase[0x00171580];
 	kmem[0] = 0x90; kmem[1] = 0x90; kmem[2] = 0x90; kmem[3] = 0x90;
 	kmem[4] = 0x90; kmem[5] = 0x65; kmem[6] = 0x8B; kmem[7] = 0x34;
-	kmem = (uint8_t *)&gKernelBase[0x11730];
+
+	// sceSblACMgrIsAllowedSystemLevelDebugging
+	kmem = (uint8_t *)&gKernelBase[0x00010FC0];
 	kmem[0] = 0xB8; kmem[1] = 0x01; kmem[2] = 0x00; kmem[3] = 0x00;
 	kmem[4] = 0x00; kmem[5] = 0xC3; kmem[6] = 0x90; kmem[7] = 0x90;
-	kmem = (uint8_t *)&gKernelBase[0x11750];
+
+	kmem = (uint8_t *)&gKernelBase[0x00011756];
 	kmem[0] = 0xB8; kmem[1] = 0x01; kmem[2] = 0x00; kmem[3] = 0x00;
 	kmem[4] = 0x00; kmem[5] = 0xC3; kmem[6] = 0x90; kmem[7] = 0x90;
 
 	// Enable rwx
-	kmem = (uint8_t*)&gKernelBase[0xFCC38];
+	kmem = (uint8_t*)&gKernelBase[0x000FCD48];
 	kmem[0] = 0x07;
-	kmem = (uint8_t*)&gKernelBase[0xFCC46];
+	kmem = (uint8_t*)&gKernelBase[0x000FCD56];
 	kmem[0] = 0x07;
 
-	// Patch copy(in/out) ?
-	uint16_t *copyinpatch = (uint16_t*)&gKernelBase[0x1EA657];
-	uint16_t *copyoutpatch = (uint16_t*)&gKernelBase[0x1EA572];
+	// Patch copy(in/out)
+	uint16_t *copyinpatch = (uint16_t*)&gKernelBase[0x001EA767];
+	uint16_t *copyoutpatch = (uint16_t*)&gKernelBase[0x001EA682];
 
 	*copyinpatch = 0x9090;
 	*copyoutpatch = 0x9090;
 
 	// Enable MAP_SELF
-	kmem = (uint8_t*)&gKernelBase[0x117b0];
+	kmem = (uint8_t*)&gKernelBase[0x000117b0];
 	kmem[0] = 0xB8;
 	kmem[1] = 0x01;
 	kmem[2] = 0x00;
@@ -57,7 +60,7 @@ void install_prerunPatches_501()
 	kmem[3] = 0x00;
 	kmem[4] = 0x00;
 	kmem[5] = 0xC3;
-	kmem = (uint8_t*)&gKernelBase[0x13ef2f];
+	kmem = (uint8_t*)&gKernelBase[0x0013F03F];
 	kmem[0] = 0x31;
 	kmem[1] = 0xC0;
 	kmem[2] = 0x90;
@@ -65,30 +68,30 @@ void install_prerunPatches_501()
 	kmem[4] = 0x90;
 
 	// Patch copyinstr
-	gKernelBase[0x001EAA83] = 0x90;
-	gKernelBase[0x001EAA84] = 0x90;
+	gKernelBase[0x001EAB93] = 0x90;
+	gKernelBase[0x001EAB93+1] = 0x90;
 
-	gKernelBase[0x001EAAB3] = 0x90;
-	gKernelBase[0x001EAAB4] = 0x90;
+	gKernelBase[0x001EABC3] = 0x90;
+	gKernelBase[0x001EABC3+1] = 0x90;
 
 	// Patch memcpy stack
-	gKernelBase[0x001EA42D] = 0xEB;
+	gKernelBase[0x001EA53D] = 0xEB;
 
 	// ptrace patches
-	gKernelBase[0x0030D633] = 0x90;
-	gKernelBase[0x0030D633 + 1] = 0x90;
-	gKernelBase[0x0030D633 + 2] = 0x90;
-	gKernelBase[0x0030D633 + 3] = 0x90;
-	gKernelBase[0x0030D633 + 4] = 0x90;
-	gKernelBase[0x0030D633 + 5] = 0x90;
+	gKernelBase[0x0030D9C3] = 0x90;
+	gKernelBase[0x0030D9C3 + 1] = 0x90;
+	gKernelBase[0x0030D9C3 + 2] = 0x90;
+	gKernelBase[0x0030D9C3 + 3] = 0x90;
+	gKernelBase[0x0030D9C3 + 4] = 0x90;
+	gKernelBase[0x0030D9C3 + 5] = 0x90;
 
 	// setlogin patch (for autolaunch check)
-	gKernelBase[0x5775C] = 0x48;
-	gKernelBase[0x5775C + 1] = 0x31;
-	gKernelBase[0x5775C + 2] = 0xC0;
-	gKernelBase[0x5775C + 3] = 0x90;
+        gKernelBase[0x5775C] = 0x48;
+        gKernelBase[0x5775C + 1] = 0x31;
+        gKernelBase[0x5775C + 2] = 0xC0;
+        gKernelBase[0x5775C + 3] = 0x90;
 	gKernelBase[0x5775C + 4] = 0x90;
 
 	cpu_enable_wp();
-	crtical_exit();
+	critical_exit();
 }


### PR DESCRIPTION
Offsets were off for 5.05FW and a few symbols were missing - this PR adds them back and fixes the patch offsets.